### PR TITLE
Remove laravel/framework dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "laravel/nova": "~3.0",
-        "laravel/framework": "^7.0|^8.0"
+        "laravel/nova": "~3.0"
     },
 
     "autoload": {


### PR DESCRIPTION
I propose removing the `laravel/framework": "^7.0|^8.0` dependency as it is not only useless (since we're requiring nova), but it currently prevents using Laravel 9.